### PR TITLE
Compatibility with Magento 2.4.7

### DIFF
--- a/src/IndexerReindexCommandPreference.php
+++ b/src/IndexerReindexCommandPreference.php
@@ -62,7 +62,7 @@ class IndexerReindexCommandPreference extends \Magento\Indexer\Console\Command\I
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $returnValue = Cli::RETURN_FAILURE;
         foreach ($this->getIndexers($input) as $indexer) {


### PR DESCRIPTION
With https://github.com/magento/magento2/blame/57a32313c47367079d64ec450a2d108b7133c491/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php#L96, the return type for this function has been set. This way, `setup:upgrade` will fail with Magento 2.4.7, if method is not declared the same way.